### PR TITLE
Add "open in colab" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Typically, if you have some programming experience, we encourage you to start on
 **Feeling nervous to submit or not sure where to start? Please join our weekly meeting and we will pair you with a mentor!**
 
 ### 1. Have a look at the example code
-We have an [example colab notebook](https://github.com/jaderabbit/masakhane/blob/master/starter_notebook.ipynb) which trains a model for English-to-Zulu translation. Open it in [Google Colab](google colab) - you can select it by going to the GitHub section when opening a new project.
-
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/masakhane-io/masakhane-mt/blob/master/starter_notebook.ipynb)  
+We have an [example colab notebook](https://github.com/jaderabbit/masakhane/blob/master/starter_notebook.ipynb) which trains a model for English-to-Zulu translation. You can select it by going to the GitHub section when opening a new project.
 
 ### 2. Finding data for my language?!
 


### PR DESCRIPTION
I was wondering if it would be helpful to add a "Open in colab" badge to the starter project section in the README so that users can get started with a single click.

Here's a link to the [colab-github badge demo](https://colab.research.google.com/github/googlecolab/colabtools/blob/master/notebooks/colab-github-demo.ipynb).