### PR TITLE
Custom Data notebook: sacremoses tokenization fix, sacrebleu tokenization in yaml, other fixes.

### DIFF
--- a/starter_notebook-custom-data.ipynb
+++ b/starter_notebook-custom-data.ipynb
@@ -85,8 +85,8 @@
     "os.environ[\"tag\"] = tag\n",
     "\n",
     "# This will save it to a folder in our gdrive instead!\n",
-    "!mkdir -p \"/content/drive/MyDrive/masakhane/$src-$tgt-$tag\"\n",
-    "os.environ[\"gdrive_path\"] = \"/content/drive/MyDrive/masakhane/%s-%s-%s\" % (source_language, target_language, tag)"
+    "!mkdir -p \"/content/drive/My Drive/masakhane/$src-$tgt-$tag\"\n",
+    "os.environ[\"gdrive_path\"] = \"/content/drive/My Drive/masakhane/%s-%s-%s\" % (source_language, target_language, tag)"
    ]
   },
   {

--- a/starter_notebook-custom-data.ipynb
+++ b/starter_notebook-custom-data.ipynb
@@ -85,8 +85,8 @@
     "os.environ[\"tag\"] = tag\n",
     "\n",
     "# This will save it to a folder in our gdrive instead!\n",
-    "!mkdir -p \"/content/drive/My Drive/masakhane/$src-$tgt-$tag\"\n",
-    "os.environ[\"gdrive_path\"] = \"/content/drive/My Drive/masakhane/%s-%s-%s\" % (source_language, target_language, tag)"
+    "!mkdir -p \"/content/drive/MyDrive/masakhane/$src-$tgt-$tag\"\n",
+    "os.environ[\"gdrive_path\"] = \"/content/drive/MyDrive/masakhane/%s-%s-%s\" % (source_language, target_language, tag)"
    ]
   },
   {

--- a/starter_notebook-custom-data.ipynb
+++ b/starter_notebook-custom-data.ipynb
@@ -53,7 +53,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "oGRmDELn7Az0"
    },
    "outputs": [],
@@ -68,7 +67,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "Cn3tgQLzUxwn"
    },
    "outputs": [],
@@ -97,12 +95,11 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "kBSgJHEw7Nvx"
    },
    "outputs": [],
    "source": [
-    "!echo $gdrive_path"
+    "!echo \"\"$gdrive_path\""
    ]
   },
   {
@@ -111,7 +108,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "gA75Fs9ys8Y9"
    },
    "outputs": [],
@@ -126,7 +122,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "xq-tDZVks7ZD"
    },
    "outputs": [],
@@ -136,16 +131,14 @@
     "target_file = \"my_file.xh\"\n",
     "\n",
     "# They should both have the same length.\n",
-    "! wc -l $source_file\n",
-    "! wc -l $target_file"
+    "! wc -l \"$source_file\"\n",
+    "! wc -l \"$target_file\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# TODO: Pre-processing! (OPTIONAL)\n",
@@ -164,13 +157,13 @@
     "tok_target_file = target_file+\".tok\"\n",
     "\n",
     "# Tokenize the source\n",
-    "! sacremoses tokenize -l $source_language < $source_file > $tok_source_file\n",
+    "! sacremoses -l \"$source_language\" tokenize < \"$source_file\" > \"$tok_source_file\"\n",
     "# Tokenize the target\n",
-    "! sacremoses tokenize -l $target_language < $target_file > $tok_target_file\n",
+    "! sacremoses -l \"$target_language\" tokenize < \"$target_file\" > \"$tok_target_file\"\n",
     "\n",
     "# Let's take a look what tokenization did to the text.\n",
-    "! head $source_file*\n",
-    "! head $target_file*\n",
+    "! head \"$source_file\"*\n",
+    "! head \"$target_file\"*\n",
     "\n",
     "# Change the pointers to our files such that we continue to work with the tokenized data.\n",
     "source_file = tok_source_file\n",
@@ -183,7 +176,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "n48GDRnP8y2G"
    },
    "outputs": [],
@@ -213,7 +205,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "NqDG-CI28y2L"
    },
    "outputs": [],
@@ -236,7 +227,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "3CNdwLBCfSIl"
    },
    "outputs": [],
@@ -285,7 +275,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "M_2ouEOH1_1q"
    },
    "outputs": [],
@@ -304,9 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Install fuzzy wuzzy to remove \"almost duplicate\" sentences in the\n",
@@ -340,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "start_time = time.time()\n",
@@ -365,7 +350,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "hxxBOCA-xXhy"
    },
    "outputs": [],
@@ -432,7 +416,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "iBRMm4kMxZ8L"
    },
    "outputs": [],
@@ -464,7 +447,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "H-TyjtmXB1mL"
    },
    "outputs": [],
@@ -491,12 +473,12 @@
     "! subword-nmt apply-bpe -c bpe.codes.4000 --vocabulary vocab.$tgt < test.$tgt > test.bpe.$tgt\n",
     "\n",
     "# Create directory, move everyone we care about to the correct location\n",
-    "! mkdir -p $data_path\n",
-    "! cp train.* $data_path\n",
-    "! cp test.* $data_path\n",
-    "! cp dev.* $data_path\n",
-    "! cp bpe.codes.4000 $data_path\n",
-    "! ls $data_path\n",
+    "! mkdir -p \"$data_path\"\n",
+    "! cp train.* \"$data_path\"\n",
+    "! cp test.* \"$data_path\"\n",
+    "! cp dev.* \"$data_path\"\n",
+    "! cp bpe.codes.4000 \"$data_path\"\n",
+    "! ls \"$data_path\"\n",
     "\n",
     "# Also move everything we care about to a mounted location in google drive (relevant if running in colab) at gdrive_path\n",
     "! cp train.* \"$gdrive_path\"\n",
@@ -510,7 +492,7 @@
     "! joeynmt/scripts/build_vocab.py joeynmt/data/$src$tgt/train.bpe.$src joeynmt/data/$src$tgt/train.bpe.$tgt --output_path joeynmt/data/$src$tgt/vocab.txt\n",
     "\n",
     "# Some output\n",
-    "! echo \"BPE Xhosa Sentences\"\n",
+    "! echo \"BPE Test language Sentences\"\n",
     "! tail -n 5 test.bpe.$tgt\n",
     "! echo \"Combined BPE Vocab\"\n",
     "! tail -n 10 joeynmt/data/$src$tgt/vocab.txt  # Herman"
@@ -522,7 +504,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "IlMitUHR8Qy-"
    },
    "outputs": [],
@@ -562,7 +543,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "PIs1lY2hxMsl"
    },
    "outputs": [],
@@ -592,6 +572,9 @@
     "testing:\n",
     "    beam_size: 5\n",
     "    alpha: 1.0\n",
+    "    sacrebleu:                      # sacrebleu options\n",
+    "        remove_whitespace: True     # `remove_whitespace` option in sacrebleu.corpus_chrf() function (defalut: True)\n",
+    "        tokenize: \"none\"            # `tokenize` option in sacrebleu.corpus_bleu() function (options include: \"none\" (use for already tokenized test data), \"13a\" (default minimal tokenizer), \"intl\" which mostly does punctuation and unicode, etc) \n",
     "\n",
     "training:\n",
     "    #load_model: \"{gdrive_path}/models/{name}_transformer/1.ckpt\" # if uncommented, load a pre-trained model from this checkpoint\n",
@@ -682,7 +665,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "6ZBPFwT94WpI"
    },
    "outputs": [],
@@ -698,12 +680,11 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "MBoDS09JM807"
    },
    "outputs": [],
    "source": [
-    "# Copy the created models from the notebook storage to google drive for persistant storage \n",
+    "# Copy the created models from the notebook storage to google drive for persistent storage \n",
     "!cp -r joeynmt/models/${src}${tgt}_transformer/* \"$gdrive_path/models/${src}${tgt}_transformer/\""
    ]
   },
@@ -713,7 +694,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "n94wlrCjVc17"
    },
    "outputs": [],
@@ -728,7 +708,6 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "collapsed": true,
     "id": "66WhRE9lIhoD"
    },
    "outputs": [],
@@ -761,9 +740,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.8"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/starter_notebook-custom-data.ipynb
+++ b/starter_notebook-custom-data.ipynb
@@ -685,7 +685,8 @@
    "outputs": [],
    "source": [
     "# Copy the created models from the notebook storage to google drive for persistent storage \n",
-    "!cp -r joeynmt/models/${src}${tgt}_transformer/* \"$gdrive_path/models/${src}${tgt}_transformer/\""
+    "! mkdir -p \"$gdrive_path/models/${src}${tgt}_transformer/\"\n",
+    "! cp -r joeynmt/models/${src}${tgt}_transformer/* \"$gdrive_path/models/${src}${tgt}_transformer/\""
    ]
   },
   {


### PR DESCRIPTION
* Apparently it's supposed to be `sacremoses -l eng tokenize file.txt`, not `sacremoses tokenize -l eng file.txt`
* added a mkdir command for saving to drive after training. 
* Adding quotations around bash variables. This seems to have improved the notebook's ability to handle spaces in file paths. 
* Set default Sacrebleu tokenizer for test data to "none", and added comment. 
* small typo fixes, etc.