### PR TITLE
Updated Language_pairs.md to reflect new accepted pull requests

### DIFF
--- a/language_pairs.md
+++ b/language_pairs.md
@@ -1,7 +1,7 @@
 # Current Language Pairs
 
 - Total number of unique language pairs: 44
-- Total number of benchmarks: 47
+- Total number of benchmarks: 52
 
 Training data for the models reported below comes from [JW300](http://opus.nlpl.eu/JW300.php) unless indicated otherwise (in brackets). For details about data source, preprocessing, training configurations etc. check the notebooks provided in the folders linked for each language pair.
 The Test BLEU score is computed on the JW300 [test sets](https://github.com/masakhane-io/masakhane-mt/tree/master/jw300_utils/test) with [SacreBLEU](https://github.com/mjpost/sacrebleu) (`tokenize=None` to maintain the original JW300 tokenization). 

--- a/language_pairs.md
+++ b/language_pairs.md
@@ -57,4 +57,7 @@ The Test BLEU score is computed on the JW300 [test sets](https://github.com/masa
 | French | Lingala | 39.81 | [link](https://github.com/masakhane-io/masakhane/tree/master/benchmarks/fr-ln/french-lingala-baseline) | :x: |
 | French | Swahili Congo | 33.73 | [link](https://github.com/masakhane-io/masakhane/tree/master/benchmarks/fr-swc/french-swahili_drc_baseline) | :x: |
 | Nigerian Pidgin | English | 24.95 | [link](https://github.com/masakhane-io/masakhane-mt/tree/master/benchmarks/pcm-en/jw300-baseline) | :x: |
+| Tshivenda | English | 46.82 | [link](https://github.com/masakhane-io/masakhane-mt/tree/master/benchmarks/ve-en/jw300-baseline) | :x: |
+| Southern Ndebele | English | 40.56 | [link](https://github.com/masakhane-io/masakhane-mt/tree/master/benchmarks/nr-en/jw300-baseline) | :x: |
+| Afrikaans (JW300) | English | 57.22 | [link](https://github.com/masakhane-io/masakhane-mt/tree/master/benchmarks/af-en/jw300-baseline) | :x: |
 

--- a/language_pairs.md
+++ b/language_pairs.md
@@ -1,6 +1,6 @@
 # Current Language Pairs
 
-- Total number of unique language pairs: 40
+- Total number of unique language pairs: 44
 - Total number of benchmarks: 47
 
 Training data for the models reported below comes from [JW300](http://opus.nlpl.eu/JW300.php) unless indicated otherwise (in brackets). For details about data source, preprocessing, training configurations etc. check the notebooks provided in the folders linked for each language pair.


### PR DESCRIPTION
Added Tshivenda, Southern Ndebele and Afrikaans -> English.

Also updated the total number of language pairs / total  number of benchmarks using this piece of code (where `file` contains only the body part of the table, i.e. English | Afrikaans | etc | to | Afrikaans (JW300) | English | :

```
import re 

with open('file', 'r') as f:
    lines = f.readlines()

    print("TOTAL = ", len(lines))

    news = []
    for l in lines:
        K = list(map(lambda x: x.replace("|", '').strip(), l.split("|")))
        K = [i for i in K if i != '']
        # print(K)
        a, b = K[:2]
        b = re.sub("[\(\[].*?[\)\]]", "", b).replace("()" , '').strip().lower()
        a = re.sub("[\(\[].*?[\)\]]", "", a).replace("()" , '').strip().lower()
        # print(f"({a}, {b})")
        news.append((a, b))
    print('Number of uniques =', len(set(news)))
```